### PR TITLE
Updated README.rst example to use correct import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Examples
 
 .. code-block:: python
 
-    >>> from whatsonchain import Whatsonchain
+    >>> from whatsonchain.api import Whatsonchain
     >>> woc = Whatsonchain(network='test')
     >>> woc.get_address_info('mtsCNJGDVgYaVm3je8UpU5nExgiJgkEv6y')
     {'address': 'mtsCNJGDVgYaVm3je8UpU5nExgiJgkEv6y',


### PR DESCRIPTION
Original docs when ran produced:

ImportError: cannot import name 'Whatsonchain' from 'whatsonchain'

The included change fixes that error.